### PR TITLE
added accessibility statement, larger footer text

### DIFF
--- a/index.html
+++ b/index.html
@@ -45,6 +45,8 @@
 	<main id="root"></main>
 	<footer>
 		<p>&copy; This application is copyright <span id="year">2024</span>, The Regents of the University of Michigan.</p>
+		<p><a href="https://docs.google.com/document/d/1Ex_rp9SqZazpDJJd725FwhHoyzLvQAQKedaBqk4yEpQ/">Accessibility</a></p>
+		<hr />
 		<p> If you would like to embed this widget in your website, please use the following code: <br>
 			<em> &lt;iframe src="https://mlibrary.github.io/medical-dictionary/" style="margin: 2em 1%; height: 650px; width: 98%; border: 2px solid #EEE;"&gt;&lt;/iframe&gt; </em>
 		</p>

--- a/index.html
+++ b/index.html
@@ -45,7 +45,7 @@
 	<main id="root"></main>
 	<footer>
 		<p>&copy; This application is copyright <span id="year">2024</span>, The Regents of the University of Michigan.</p>
-		<p><a href="https://docs.google.com/document/d/1Ex_rp9SqZazpDJJd725FwhHoyzLvQAQKedaBqk4yEpQ/">Accessibility</a></p>
+		<p><a href="https://docs.google.com/document/d/1Ex_rp9SqZazpDJJd725FwhHoyzLvQAQKedaBqk4yEpQ/" rel="noopener">Accessibility</a></p>
 		<hr />
 		<p> If you would like to embed this widget in your website, please use the following code: <br>
 			<em> &lt;iframe src="https://mlibrary.github.io/medical-dictionary/" style="margin: 2em 1%; height: 650px; width: 98%; border: 2px solid #EEE;"&gt;&lt;/iframe&gt; </em>

--- a/style.css
+++ b/style.css
@@ -113,7 +113,6 @@ footer p{
 
 footer a{
   color: white;
-  font-size: 1rem;
 }
 
 

--- a/style.css
+++ b/style.css
@@ -106,9 +106,14 @@ footer{
 footer p{
   margin-right: 1.5em;
   margin-left: 1.5em;
-  font-size: 0.7em;
+  font-size: 1em;
   margin-top: 0.2em;
   line-height: 1.5em;
+}
+
+footer a{
+  color: white;
+  font-size: 1rem;
 }
 
 


### PR DESCRIPTION
This PR adds an accessibility link to the footer which links to the accessibility statement.

It also makes the footer text larger (16px) and adds an `<hr>` between the accessibility `<p>` and the embed code to help visually break up the footer.